### PR TITLE
Nearest traffic light + light state oracle

### DIFF
--- a/ros/launch/styx.launch
+++ b/ros/launch/styx.launch
@@ -20,4 +20,10 @@
 
     <!--Traffic Light Locations and Camera Config -->
     <param name="traffic_light_config" textfile="$(find tl_detector)/sim_traffic_light_config.yaml" />
+
+    <arg name="log_level" default="info" doc="Valid values: {info, debug}"/>
+    <param name="log_level" value="$(arg log_level)" />
+
+    <arg name="get_light" default="detect" doc="Method to get traffic light state. Valid values: {detect, oracle}"/>
+    <param name="get_light" value="$(arg get_light)" />
 </launch>


### PR DESCRIPTION
This PR makes `tl_detector.py` able to find the next traffic light and the closest way point to the corresponding stop line. It also makes an oracle mode in which the traffic light state is returned based on the topic `/vehicle/traffic_lights`.

To test it, launch it with debug log_level and oracle mode as follows:
``
roslaunch launch/styx.launch log_level:=debug get_light:=oracle
``
Check the CAMERA check box and drive the car manually. Check consistency of the debug information about traffic light and car position in the terminal.
Note that the traffic light is considered not visible if it is further than 100 meters.