### PR TITLE
Capture training data for traffic light classifier

### DIFF
--- a/ros/launch/styx.launch
+++ b/ros/launch/styx.launch
@@ -20,4 +20,10 @@
 
     <!--Traffic Light Locations and Camera Config -->
     <param name="traffic_light_config" textfile="$(find tl_detector)/sim_traffic_light_config.yaml" />
+
+    <arg name="log_level" default="info" doc="Valid values: {info, debug}"/>
+    <param name="log_level" value="$(arg log_level)" />
+
+    <arg name="get_light" default="detect" doc="Method to get traffic light state. Valid values: {detect, oracle}"/>
+    <param name="get_light" value="$(arg get_light)" />
 </launch>

--- a/ros/launch/styx.launch
+++ b/ros/launch/styx.launch
@@ -26,4 +26,7 @@
 
     <arg name="get_light" default="detect" doc="Method to get traffic light state. Valid values: {detect, oracle}"/>
     <param name="get_light" value="$(arg get_light)" />
+
+    <arg name="record_path" default="" doc="Directory path to save training data."/>
+    <param name="record_path" value="$(arg record_path)" />
 </launch>

--- a/ros/launch/styx.launch
+++ b/ros/launch/styx.launch
@@ -16,17 +16,20 @@
     <include file="$(find waypoint_updater)/launch/waypoint_updater.launch"/>
 
     <!--Traffic Light Detector Node -->
-    <!-- <include file="$(find tl_detector)/launch/tl_detector.launch"/> -->
+    <include file="$(find tl_detector)/launch/tl_detector.launch"/>
 
     <!--Traffic Light Locations and Camera Config -->
+    <param name="traffic_light_config" textfile="$(find tl_detector)/sim_traffic_light_config.yaml" />
 
-    <!-- <param name="traffic_light_config" textfile="$(find tl_detector)/sim_traffic_light_config.yaml" /> -->
-
+    <!--Logging Level -->
     <arg name="log_level" default="info" doc="Valid values: {info, debug}"/>
     <param name="log_level" value="$(arg log_level)" />
 
+    <!--Traffic Light Detection Mode -->
     <arg name="get_light" default="detect" doc="Method to get traffic light state. Valid values: {detect, oracle}"/>
     <param name="get_light" value="$(arg get_light)" />
+
+    <!--Data Recording Path -->
     <arg name="record_path" default="" doc="Directory path to save training data."/>
     <param name="record_path" value="$(arg record_path)" />
 </launch>


### PR DESCRIPTION
This PR is to be reviewed after PR #3 and PR #7, as it is based on top of the corresponding branches.
It makes tl_detector.py able to save images from the camera in directories structured as expected by the script `retrain.py` from tensorflow. The saved images will make possible to fine tune an image classifier to infer the states of the traffic lights.
To test it:
```bash
roslaunch launch/styx.launch get_light:=oracle record_path:="/path-where-to-save-the-captures/"
```
Check Camera in the simulator and uncheck Manual. Then when the car comes close to the traffic lights, it starts recording the images.

It uses the traffic light state given by topic `/vehicle/traffic_lights` to automatically save each image in the corresponding subdirectory. There are some rare mistake sometimes though because of minor timing issue. So the data actually needs to be visually curated after recording, but I think the tool is good enough. I have already used it to gather around 5,000 images, which I'll post on slack.
Also sometimes it records images where the color of the traffic light is not visible but still assign it to a known state. In such a case I just move manually the images to the `4_unknown` subdirectory.